### PR TITLE
Load config values from yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ dmypy.json
 # Misc
 .*.swp
 .idea/
+/config.yaml

--- a/config.template.yaml
+++ b/config.template.yaml
@@ -1,0 +1,2 @@
+---
+email_address: 'example@example.com'

--- a/mealpy.py
+++ b/mealpy.py
@@ -1,8 +1,10 @@
 import getpass
 import json
 import time
+from os import path
 
 import requests
+import strictyaml
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 BASE_DOMAIN = 'secure.mealpal.com'
@@ -23,11 +25,20 @@ HEADERS = {
 }
 
 
+def load_config():
+    schema = strictyaml.Map({
+        'email_address': strictyaml.Email(),
+    })
+
+    root_dir = path.abspath(path.dirname(__file__))
+    with open(path.join(root_dir, 'config.yaml')) as config_file:
+        return strictyaml.load(config_file.read(), schema).data
+
+
 class MealPal():
 
     def __init__(self):
         self.cookies = None
-        self.cities = None
 
     def login(self, username, password):
         data = {'username': username, 'password': password}
@@ -97,8 +108,6 @@ class MealPal():
 
 
 SCHEDULER = BlockingScheduler()
-EMAIL = input('Enter email: ')
-PASSWORD = getpass.getpass('Enter password: ')
 
 
 @SCHEDULER.scheduled_job('cron', hour=16, minute=59, second=58)
@@ -136,4 +145,7 @@ def execute_reserve_meal():
 
 
 if __name__ == '__main__':
+    EMAIL = load_config()['email_address']
+    PASSWORD = getpass.getpass('Enter password: ')
+
     execute_reserve_meal()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 apscheduler
 requests
+strictyaml


### PR DESCRIPTION
This reduces one user input, makes the script more hands-off.

This change is independent and can be shipped as-is. Together with #15, it will fix #6 and make the script a one-time setup.