### PR TITLE
Move configs to XDG directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 Reserve your meals on MealPal automatically, as soon as the kitchen opens.
 Never miss your favourite MealPal meals again!
 
+## Description
+
+*[MealPal](https://www.mealpal.com) offers lunch and dinner subscriptions giving you access to the best restaurants
+for less than $6 per meal.*
+
+This script automates the ordering process by allowing you to specify your desired restaurant and pickup timing in
+advance. Just run the script before the MealPal kitchen opens at 5pm to get your order, and beat the competition to
+getting the meals from popular restaurants!
+
 ## Installation
 
 Install virtualenv with all required dependencies and activate it:
@@ -12,24 +21,28 @@ make venv
 source venv/bin/activate
 ```
 
-## Help
+## Quickstart
 
 ```bash
 python mealpy/mealpy.py --help
 ```
 
-## Reserve a meal
+### Reserve a meal
 
 ```bash
 # python mealpy.py reserve RESTAURANT RESERVATION_TIME CITY
 python mealpy.py reserve "Coast Poke Counter - Battery St." "12:15pm-12:30pm" "San Francisco"
 ```
 
-## Description
+## Files
 
-*[MealPal](https://www.mealpal.com) offers lunch and dinner subscriptions giving you access to the best restaurants
-for less than $6 per meal.*
+### Configuration
 
-This script automates the ordering process by allowing you to specify your desired restaurant and pickup timing in
-advance. Just run the script before the MealPal kitchen opens at 5pm to get your order, and beat the competition to
-getting the meals from popular restaurants!
+Upon the first run, a config will be created in $XDG_CONFIG_HOME (~/.config/mealpy) from the [template](config.template.yaml).
+You'll can override the default values.
+
+### Cookies
+
+This script stores cookies created from initial login.
+This is how the script can rerun without re-asking every time.
+This can be found in $XDG_CACHE_HOME (~/.cache/mealpy).

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -2,3 +2,4 @@ apscheduler
 click
 requests
 strictyaml
+xdg

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six==1.12.0
 strictyaml==1.0.1
 tzlocal==1.5.1
 urllib3==1.24.2
+xdg==4.0.0


### PR DESCRIPTION
This change will put files into XDG directories (by default $HOME/.{config,cache,local}). This keeps the deployment clean, as user does not need to maintain stateful files in the install directory, they can simply clobber it if they want to update. And gives user ability to configure where their configs live.

I switched over to using `pathlib`, which is the spiritual successor to `os.path`. Like subprocess, system, popen, it's all a hot mess of history and baggage.

Fixes #22 