### PR TITLE
Fix reservation request post args

### DIFF
--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -126,7 +126,7 @@ class MealPal:
             'source': 'Web',
         }
 
-        request = self.session.post(RESERVATION_URL, data=reserve_data)
+        request = self.session.post(RESERVATION_URL, json=reserve_data)
         return request.status_code
 
     def get_current_meal(self):


### PR DESCRIPTION
#25 Removes a necessary json.dumps of the post parameters as a request, which causes all requests to MealPal to fail with a bad request message.

Tests still pass with this change