### PR TITLE
Add tests for config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ---
 exclude: ^bin/
-fail_fast: true
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.2.3

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ venv:
 .PHONY: test
 test: venv
 	venv/bin/coverage run -m pytest --strict tests/
-	venv/bin/coverage report --show-missing --skip-covered --fail-under 61 --omit 'tests/*'
+	venv/bin/coverage report --show-missing --skip-covered --fail-under 64 --omit 'tests/*'
 	venv/bin/coverage report --show-missing --skip-covered --fail-under 100 --include 'tests/*'
 	venv/bin/check-requirements
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ venv:
 .PHONY: test
 test: venv
 	venv/bin/coverage run -m pytest --strict tests/
-	venv/bin/coverage report --show-missing --skip-covered --fail-under 54 --omit 'tests/*'
+	venv/bin/coverage report --show-missing --skip-covered --fail-under 61 --omit 'tests/*'
 	venv/bin/coverage report --show-missing --skip-covered --fail-under 100 --include 'tests/*'
+	venv/bin/check-requirements
 
 .PHONY: clean
 clean: ## Clean working directory

--- a/mealpy/__main__.py
+++ b/mealpy/__main__.py
@@ -1,0 +1,5 @@
+from mealpy.mealpy import cli
+
+
+if __name__ == '__main__':
+    cli()

--- a/mealpy/config.py
+++ b/mealpy/config.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from shutil import copyfile
+
+import strictyaml
+import xdg
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+CONFIG_FILENAME = 'config.yaml'
+
+
+def initialize_directories():  # pragma: no cover
+    """Mkdir all directories mealpy uses."""
+    cache = Path(xdg.XDG_CACHE_HOME) / 'mealpy'
+    config = Path(xdg.XDG_CONFIG_HOME) / 'mealpy'
+
+    for i in (cache, config):
+        i.mkdir(parents=True, exist_ok=True)
+
+
+def load_config_from_file(config_file: Path, schema: strictyaml.Map):
+    return strictyaml.load(config_file.read_text(), schema).data
+
+
+def load_config():
+    schema = strictyaml.Map({
+        'email_address': strictyaml.Email(),
+        'use_keyring': strictyaml.Bool(),
+    })
+
+    template_config_path = ROOT_DIR / 'config.template.yaml'
+
+    config_path = xdg.XDG_CONFIG_HOME / 'mealpy' / CONFIG_FILENAME
+
+    # Create config file if it doesn't already exist
+    if not config_path.exists():
+        copyfile(str(template_config_path), str(config_path))
+        exit(
+            f'{config_path} has been created.\n'
+            f'Please update the email_address field in {config_path} with your email address for MealPal.',
+        )
+
+    config = load_config_from_file(template_config_path, schema)
+    config.update(load_config_from_file(config_path, schema))
+    return config

--- a/mealpy/config.py
+++ b/mealpy/config.py
@@ -6,14 +6,14 @@ import strictyaml
 import xdg
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
+CACHE_DIR = xdg.XDG_CACHE_HOME / 'mealpy'
+CONFIG_DIR = xdg.XDG_CONFIG_HOME / 'mealpy'
 
 
 def initialize_directories():  # pragma: no cover
     """Mkdir all directories mealpy uses."""
-    cache = xdg.XDG_CACHE_HOME / 'mealpy'
-    config = xdg.XDG_CONFIG_HOME / 'mealpy'
 
-    for i in (cache, config):
+    for i in (CACHE_DIR, CONFIG_DIR):
         i.mkdir(parents=True, exist_ok=True)
 
 
@@ -33,7 +33,7 @@ def get_config():
     template_config_path = ROOT_DIR / 'config.template.yaml'
     assert template_config_path.exists()
 
-    config_path = xdg.XDG_CONFIG_HOME / 'mealpy' / 'config.yaml'
+    config_path = CONFIG_DIR / 'config.yaml'
 
     # Create config file if it doesn't already exist
     if not config_path.exists():  # pragma: no cover

--- a/mealpy/config.py
+++ b/mealpy/config.py
@@ -1,46 +1,48 @@
 from functools import lru_cache
 from pathlib import Path
-from shutil import copyfile
+from shutil import copyfileobj
 
 import strictyaml
 import xdg
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
-CONFIG_FILENAME = 'config.yaml'
 
 
 def initialize_directories():  # pragma: no cover
     """Mkdir all directories mealpy uses."""
-    cache = Path(xdg.XDG_CACHE_HOME) / 'mealpy'
-    config = Path(xdg.XDG_CONFIG_HOME) / 'mealpy'
+    cache = xdg.XDG_CACHE_HOME / 'mealpy'
+    config = xdg.XDG_CONFIG_HOME / 'mealpy'
 
     for i in (cache, config):
         i.mkdir(parents=True, exist_ok=True)
 
 
-def load_config_from_file(config_file: Path, schema: strictyaml.Map):
-    return strictyaml.load(config_file.read_text(), schema).data
-
-
-@lru_cache(maxsize=1)
-def get_config():
+def load_config_from_file(config_file: Path):  # pragma: no cover
     schema = strictyaml.Map({
         'email_address': strictyaml.Email(),
         'use_keyring': strictyaml.Bool(),
     })
 
-    template_config_path = ROOT_DIR / 'config.template.yaml'
+    return strictyaml.load(config_file.read_text(), schema).data
 
-    config_path = xdg.XDG_CONFIG_HOME / 'mealpy' / CONFIG_FILENAME
+
+@lru_cache(maxsize=1)
+def get_config():
+    initialize_directories()
+
+    template_config_path = ROOT_DIR / 'config.template.yaml'
+    assert template_config_path.exists()
+
+    config_path = xdg.XDG_CONFIG_HOME / 'mealpy' / 'config.yaml'
 
     # Create config file if it doesn't already exist
-    if not config_path.exists():
-        copyfile(str(template_config_path), str(config_path))
+    if not config_path.exists():  # pragma: no cover
+        copyfileobj(template_config_path.open(), config_path.open('w'))
         exit(
             f'{config_path} has been created.\n'
             f'Please update the email_address field in {config_path} with your email address for MealPal.',
         )
 
-    config = load_config_from_file(template_config_path, schema)
-    config.update(load_config_from_file(config_path, schema))
+    config = load_config_from_file(template_config_path)
+    config.update(load_config_from_file(config_path))
     return config

--- a/mealpy/config.py
+++ b/mealpy/config.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 from shutil import copyfile
 
@@ -21,7 +22,8 @@ def load_config_from_file(config_file: Path, schema: strictyaml.Map):
     return strictyaml.load(config_file.read_text(), schema).data
 
 
-def load_config():
+@lru_cache(maxsize=1)
+def get_config():
     schema = strictyaml.Map({
         'email_address': strictyaml.Email(),
         'use_keyring': strictyaml.Bool(),

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -158,7 +158,7 @@ def initialize_mealpal():
 
 @click.group()
 def cli():
-    config.initialize_directories()
+    pass
 
 
 # SCHEDULER = BlockingScheduler()

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -107,8 +107,7 @@ class MealPal:
 
 
 def get_mealpal_credentials():
-    _config = config.load_config()
-    email = _config['email_address']
+    email = config.get_config()['email_address']
     password = getpass.getpass('Enter password: ')
     return email, password
 

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -3,6 +3,7 @@ flake8
 ipython
 pre-commit
 pudb
+pyfakefs
 pylint
 pytest
 requirements-tools

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -6,5 +6,6 @@ pudb
 pyfakefs
 pylint
 pytest
+pytest-antilru
 requirements-tools
 responses

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ coverage==4.5.3
 decorator==4.4.0
 entrypoints==0.3
 flake8==3.7.7
-identify==1.4.1
+identify==1.4.2
 importlib-metadata==0.9
 importlib-resources==1.0.2
 ipython==7.5.0
@@ -34,14 +34,15 @@ pyflakes==2.1.1
 Pygments==2.3.1
 pylint==2.3.1
 pytest==4.4.1
+pytest-antilru==1.0.5
 PyYAML==5.1
 requirements-tools==1.2.1
 responses==0.10.6
 toml==0.10.0
 traitlets==4.3.2
-typed-ast==1.3.4
+typed-ast==1.3.5
 urwid==2.0.1
 virtualenv==16.5.0
 wcwidth==0.1.7
 wrapt==1.11.1
-zipp==0.3.3
+zipp==0.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,6 +29,7 @@ ptyprocess==0.6.0
 pudb==2019.1
 py==1.8.0
 pycodestyle==2.5.0
+pyfakefs==3.5.8
 pyflakes==2.1.1
 Pygments==2.3.1
 pylint==2.3.1

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+from mealpy import config
+
+
+@pytest.fixture
+def mock_config_template(mock_fs):
+    template_config_path = config.ROOT_DIR / 'config.template.yaml'
+    mock_fs.create_file(template_config_path, contents='test')
+    yield template_config_path
+
+
+@pytest.mark.usefixtures('mock_fs')
+def test_get_config_config_not_exist(mock_config_template):
+    with pytest.raises(SystemExit), \
+            mock.patch.object(config, 'copyfileobj') as copyfileobj:
+        config.get_config()
+
+    assert copyfileobj.called, 'Template should be copied to user config.'

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -5,17 +6,58 @@ import pytest
 from mealpy import config
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mock_config_template(mock_fs):
+    """Fixture to bypass pyfakefs and use real template file from repo."""
     template_config_path = config.ROOT_DIR / 'config.template.yaml'
-    mock_fs.create_file(template_config_path, contents='test')
+    mock_fs.add_real_file(template_config_path)
     yield template_config_path
 
 
-@pytest.mark.usefixtures('mock_fs')
-def test_get_config_config_not_exist(mock_config_template):
+@pytest.fixture
+def mock_config(mock_fs):
+    """Fixture to generate a user config file."""
+    config_path = config.CONFIG_DIR / 'config.yaml'
+
+    mock_fs.create_file(
+        config_path,
+        contents=dedent('''\
+            ---
+            email_address: 'test@test.com'
+            use_keyring: False
+        '''),
+    )
+    yield config_path
+
+
+def test_get_config_config_not_exist(mock_config_template, mock_fs):
+    """Test that config template is copied over to user config."""
     with pytest.raises(SystemExit), \
             mock.patch.object(config, 'copyfileobj') as copyfileobj:
         config.get_config()
 
     assert copyfileobj.called, 'Template should be copied to user config.'
+
+
+def test_get_config_override(mock_config_template, mock_config, mock_fs):
+    """Test that user config values override default values."""
+    _config = config.get_config()
+
+    assert _config['email_address'] == 'test@test.com'
+
+
+@pytest.mark.xfail(
+    raises=config.strictyaml.YAMLValidationError,
+    reason='User config values are not optionally merged with default, #23',
+)
+def test_get_config_missing_values(mock_config_template, mock_config, mock_fs):  # pragma: no cover
+    """Test that config will default to values from template if user did not override."""
+    mock_config.write_text(dedent('''\
+        ---
+        email_address: 'test@test.com'
+    '''))
+
+    _config = config.get_config()
+
+    assert _config['email_address'] == 'test@test.com', 'email_address should come from user config override.'
+    assert not _config['use_keyring'], 'use_keyring should be default value from template.'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import xdg
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+from mealpy import config
+
+
+@pytest.fixture()
+def mock_fs():
+    """ Fake filesystem. """
+    with Patcher(modules_to_reload=[config, xdg]) as patcher:
+        yield patcher.fs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,14 @@ from mealpy import config
 
 @pytest.fixture()
 def mock_fs():
-    """ Fake filesystem. """
-    with Patcher(modules_to_reload=[config, xdg]) as patcher:
+    """Mock filesystem calls with pyfakefs."""
+
+    # Ordering matters for reloading modules. Patch upstream dependencies first, otherwise downstream dependencies will
+    # "cache" before monkey-patching occurs. i.e. config uses xdg, xdg needs to be reloaded first
+    modules_to_reload = [
+        xdg,
+        config,
+    ]
+
+    with Patcher(modules_to_reload=modules_to_reload) as patcher:
         yield patcher.fs


### PR DESCRIPTION
I moved the config logic to a separate module and added tests.

Summary of changes, in addition to the overall goal above:
* made this an executable package (`python -m mealpy reserve foo bar baz`)
* Added `check-requirements` check, it checks there are no requirements missing or extra from `requirements.txt`
* [`pyfakefs`] for effectively mocking file IO from `open`, `pathlib`, `os.path`, etc. Allows for running tests without accidentally reading/writing real files (which I most certainly did by accident lol)
* [`pytest-antilru`] for busting `lru_cache` under test

[`pytest-antilru`]: /ipwnponies/pytest-antilru
[`pyfakefs`]: https://jmcgeheeiv.github.io/pyfakefs/release/index.html