### PR TITLE
List restaurants and cities from cli

### DIFF
--- a/mealpy/__main__.py
+++ b/mealpy/__main__.py
@@ -1,5 +1,3 @@
 from mealpy.mealpy import cli
 
-
-if __name__ == '__main__':
-    cli()
+cli(prog_name=__package__)  # pylint: disable=unexpected-keyword-arg

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -192,3 +192,13 @@ def execute_reserve_meal(restaurant, reservation_time, city):
 @click.argument('city')
 def reserve(restaurant, reservation_time, city):
     execute_reserve_meal(restaurant, reservation_time, city)
+
+
+@cli.group(name='list')
+def cli_list():  # pragma: no cover
+    pass
+
+
+@cli_list.command('cities', short_help='List available cities.')
+def cli_list_cities():  # pragma: no cover
+    print('\n'.join(MealPal().get_cities()))

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -37,6 +37,26 @@ def get_cities():
     return result
 
 
+def get_schedules(city_name):
+    city_id = next((i['objectId'] for i in get_cities() if i['name'] == city_name), None)
+    request = requests.get(MENU_URL.format(city_id))
+    request.raise_for_status()
+    return request.json()['schedules']
+
+
+def get_schedule_by_restaurant_name(restaurant_name, city_name):
+    restaurant = next(
+        i
+        for i in get_schedules(city_name)
+        if i['restaurant']['name'] == restaurant_name
+    )
+    return restaurant
+
+
+def get_schedule_by_meal_name(meal_name, city_name):
+    return next(i for i in get_schedules(city_name) if i['meal']['name'] == meal_name)
+
+
 class MealPal:
 
     def __init__(self):
@@ -54,23 +74,6 @@ class MealPal:
 
         return request.status_code
 
-    def get_schedules(self, city_name):
-        city_id = next((i['objectId'] for i in get_cities() if i['name'] == city_name), None)
-        request = self.session.get(MENU_URL.format(city_id))
-        request.raise_for_status()
-        return request.json()['schedules']
-
-    def get_schedule_by_restaurant_name(self, restaurant_name, city_name):
-        restaurant = next(
-            i
-            for i in self.get_schedules(city_name)
-            if i['restaurant']['name'] == restaurant_name
-        )
-        return restaurant
-
-    def get_schedule_by_meal_name(self, meal_name, city_name):
-        return next(i for i in self.get_schedules(city_name) if i['meal']['name'] == meal_name)
-
     def reserve_meal(
             self,
             timing,
@@ -84,9 +87,9 @@ class MealPal:
             self.cancel_current_meal()
 
         if meal_name:
-            schedule_id = self.get_schedule_by_meal_name(meal_name, city_name)['id']
+            schedule_id = get_schedule_by_meal_name(meal_name, city_name)['id']
         else:
-            schedule_id = self.get_schedule_by_restaurant_name(restaurant_name, city_name)['id']
+            schedule_id = get_schedule_by_restaurant_name(restaurant_name, city_name)['id']
 
         reserve_data = {
             'quantity': 1,
@@ -127,7 +130,7 @@ def initialize_mealpal():
             sleep_duration = 1
             for _ in range(5):
                 try:
-                    mealpal.get_schedules('San Francisco')
+                    get_schedules('San Francisco')
                 except requests.HTTPError:
                     # Possible fluke, retry validation
                     print(f'Login using cookies failed, retrying after {sleep_duration} second(s).')
@@ -203,3 +206,17 @@ def cli_list():  # pragma: no cover
 def cli_list_cities():  # pragma: no cover
     cities = [i['name'] for i in get_cities()]
     print('\n'.join(cities))
+
+
+@cli_list.command('restaurants', short_help='List available restaurants.')
+@click.argument('city')
+def cli_list_restaurants(city):  # pragma: no cover
+    restaurants = [i['restaurant']['name'] for i in get_schedules(city)]
+    print('\n'.join(restaurants))
+
+
+@cli_list.command('meals', short_help='List meal choices.')
+@click.argument('city')
+def cli_list_meals(city):  # pragma: no cover
+    restaurants = [i['meal']['name'] for i in get_schedules(city)]
+    print('\n'.join(restaurants))

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -28,6 +28,15 @@ HEADERS = {
 COOKIES_FILENAME = 'cookies.txt'
 
 
+def get_cities():
+    response = requests.post(CITIES_URL)
+    response.raise_for_status()
+
+    result = response.json()['result']
+
+    return result
+
+
 class MealPal:
 
     def __init__(self):
@@ -45,17 +54,8 @@ class MealPal:
 
         return request.status_code
 
-    def get_cities(self):
-        request = self.session.post(CITIES_URL)
-        request.raise_for_status()
-        return request.json()['result']
-
-    def get_city(self, city_name):
-        city = next((i for i in self.get_cities() if i['name'] == city_name), None)
-        return city
-
     def get_schedules(self, city_name):
-        city_id = self.get_city(city_name)['objectId']
+        city_id = next((i['objectId'] for i in get_cities() if i['name'] == city_name), None)
         request = self.session.get(MENU_URL.format(city_id))
         request.raise_for_status()
         return request.json()['schedules']
@@ -201,4 +201,5 @@ def cli_list():  # pragma: no cover
 
 @cli_list.command('cities', short_help='List available cities.')
 def cli_list_cities():  # pragma: no cover
-    print('\n'.join(MealPal().get_cities()))
+    cities = [i['name'] for i in get_cities()]
+    print('\n'.join(cities))

--- a/mealpy/mealpy.py
+++ b/mealpy/mealpy.py
@@ -160,7 +160,7 @@ def initialize_mealpal():
 
 
 @click.group()
-def cli():
+def cli():  # pragma: no cover
     pass
 
 
@@ -193,7 +193,7 @@ def execute_reserve_meal(restaurant, reservation_time, city):
 @click.argument('restaurant')
 @click.argument('reservation_time')
 @click.argument('city')
-def reserve(restaurant, reservation_time, city):
+def reserve(restaurant, reservation_time, city):  # pragma: no cover
     execute_reserve_meal(restaurant, reservation_time, city)
 
 

--- a/tests/mealpy_test.py
+++ b/tests/mealpy_test.py
@@ -233,9 +233,7 @@ class TestSchedule:
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_restaurant_name(mock_city):
-        mealpal = mealpy.MealPal()
-
-        schedule = mealpal.get_schedule_by_restaurant_name('RestaurantName', mock_city.name)
+        schedule = mealpy.get_schedule_by_restaurant_name('RestaurantName', mock_city.name)
 
         meal = schedule['meal']
         restaurant = schedule['restaurant']
@@ -254,27 +252,21 @@ class TestSchedule:
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_restaurant_name_not_found(mock_city):
-        mealpal = mealpy.MealPal()
-
         # TODO(#24):  Handle invalid restaurant
         with pytest.raises(StopIteration):
-            mealpal.get_schedule_by_restaurant_name('NotFound', mock_city.name)
+            mealpy.get_schedule_by_restaurant_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_meal_name_not_found(mock_city):
-        mealpal = mealpy.MealPal()
-
         # TODO(#24):  Handle invalid restaurant
         with pytest.raises(StopIteration):
-            mealpal.get_schedule_by_meal_name('NotFound', mock_city.name)
+            mealpy.get_schedule_by_meal_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_meal_name(mock_city):
-        mealpal = mealpy.MealPal()
-
-        schedule = mealpal.get_schedule_by_meal_name('Spam and Eggs', mock_city.name)
+        schedule = mealpy.get_schedule_by_meal_name('Spam and Eggs', mock_city.name)
 
         meal = schedule['meal']
         restaurant = schedule['restaurant']
@@ -299,10 +291,8 @@ class TestSchedule:
             status=400,
         )
 
-        mealpal = mealpy.MealPal()
-
         with pytest.raises(requests.HTTPError):
-            mealpal.get_schedules(mock_city.name)
+            mealpy.get_schedules(mock_city.name)
 
 
 class TestCurrentMeal:
@@ -551,7 +541,7 @@ class TestReserve:
         schedule_id = 1
         timing = 'mock_timing'
         with mock.patch.object(
-                mealpy.MealPal,
+                mealpy,
                 'get_schedule_by_meal_name',
                 return_value={'id': schedule_id},
         ) as mock_get_schedule_by_meal, \
@@ -580,7 +570,7 @@ class TestReserve:
         schedule_id = 1
         timing = 'mock_timing'
         with mock.patch.object(
-                mealpy.MealPal,
+                mealpy,
                 'get_schedule_by_restaurant_name',
                 return_value={'id': schedule_id},
         ) as mock_get_schedule_by_restaurant, \

--- a/tests/mealpy_test.py
+++ b/tests/mealpy_test.py
@@ -75,7 +75,7 @@ class TestCity:
             json=response,
         )
 
-        cities = mealpy.get_cities()
+        cities = mealpy.MealPal.get_cities()
         city = [i for i in cities if i['name'] == 'San Francisco'][0]
 
         assert city.items() >= {
@@ -93,7 +93,7 @@ class TestCity:
         )
 
         with pytest.raises(requests.exceptions.HTTPError):
-            mealpy.get_cities()
+            mealpy.MealPal.get_cities()
 
 
 class TestLogin:
@@ -233,7 +233,7 @@ class TestSchedule:
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_restaurant_name(mock_city):
-        schedule = mealpy.get_schedule_by_restaurant_name('RestaurantName', mock_city.name)
+        schedule = mealpy.MealPal.get_schedule_by_restaurant_name('RestaurantName', mock_city.name)
 
         meal = schedule['meal']
         restaurant = schedule['restaurant']
@@ -256,7 +256,7 @@ class TestSchedule:
         reason='#24 Invalid restaurant input not handled',
     )
     def test_get_schedule_by_restaurant_name_not_found(mock_city):
-        mealpy.get_schedule_by_restaurant_name('NotFound', mock_city.name)
+        mealpy.MealPal.get_schedule_by_restaurant_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
@@ -265,12 +265,12 @@ class TestSchedule:
         reason='#24 Invalid meal name not handled',
     )
     def test_get_schedule_by_meal_name_not_found(mock_city):
-        mealpy.get_schedule_by_meal_name('NotFound', mock_city.name)
+        mealpy.MealPal.get_schedule_by_meal_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
     def test_get_schedule_by_meal_name(mock_city):
-        schedule = mealpy.get_schedule_by_meal_name('Spam and Eggs', mock_city.name)
+        schedule = mealpy.MealPal.get_schedule_by_meal_name('Spam and Eggs', mock_city.name)
 
         meal = schedule['meal']
         restaurant = schedule['restaurant']
@@ -296,7 +296,7 @@ class TestSchedule:
         )
 
         with pytest.raises(requests.HTTPError):
-            mealpy.get_schedules(mock_city.name)
+            mealpy.MealPal.get_schedules(mock_city.name)
 
 
 class TestCurrentMeal:
@@ -545,7 +545,7 @@ class TestReserve:
         schedule_id = 1
         timing = 'mock_timing'
         with mock.patch.object(
-                mealpy,
+                mealpy.MealPal,
                 'get_schedule_by_meal_name',
                 return_value={'id': schedule_id},
         ) as mock_get_schedule_by_meal, \
@@ -574,7 +574,7 @@ class TestReserve:
         schedule_id = 1
         timing = 'mock_timing'
         with mock.patch.object(
-                mealpy,
+                mealpy.MealPal,
                 'get_schedule_by_restaurant_name',
                 return_value={'id': schedule_id},
         ) as mock_get_schedule_by_restaurant, \

--- a/tests/mealpy_test.py
+++ b/tests/mealpy_test.py
@@ -251,17 +251,21 @@ class TestSchedule:
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
+    @pytest.mark.xfail(
+        raises=StopIteration,
+        reason='#24 Invalid restaurant input not handled',
+    )
     def test_get_schedule_by_restaurant_name_not_found(mock_city):
-        # TODO(#24):  Handle invalid restaurant
-        with pytest.raises(StopIteration):
-            mealpy.get_schedule_by_restaurant_name('NotFound', mock_city.name)
+        mealpy.get_schedule_by_restaurant_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
+    @pytest.mark.xfail(
+        raises=StopIteration,
+        reason='#24 Invalid meal name not handled',
+    )
     def test_get_schedule_by_meal_name_not_found(mock_city):
-        # TODO(#24):  Handle invalid restaurant
-        with pytest.raises(StopIteration):
-            mealpy.get_schedule_by_meal_name('NotFound', mock_city.name)
+        mealpy.get_schedule_by_meal_name('NotFound', mock_city.name)
 
     @staticmethod
     @pytest.mark.usefixtures('mock_get_city', 'menu_url_response')
@@ -449,10 +453,10 @@ class TestCurrentMeal:
         }
 
     @staticmethod
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_cancel_current_meal():
         mealpal = mealpy.MealPal()
-        with pytest.raises(NotImplementedError):
-            mealpal.cancel_current_meal()
+        mealpal.cancel_current_meal()
 
 
 class TestReserve:
@@ -600,6 +604,7 @@ class TestReserve:
             mealpal.reserve_meal(mock.sentinel.timing, mock.sentinel.city)
 
     @staticmethod
+    @pytest.mark.xfail(raises=NotImplementedError)
     def test_reserve_meal_cancel_meal():
         """Test that meal can be canceled before reserving.
 
@@ -608,10 +613,9 @@ class TestReserve:
         """
         mealpal = mealpy.MealPal()
 
-        with pytest.raises(NotImplementedError):
-            mealpal.reserve_meal(
-                'mock_timing',
-                'mock_city',
-                restaurant_name='restaurant_name',
-                cancel_current_meal=True,
-            )
+        mealpal.reserve_meal(
+            'mock_timing',
+            'mock_city',
+            restaurant_name='restaurant_name',
+            cancel_current_meal=True,
+        )

--- a/tests/mealpy_test.py
+++ b/tests/mealpy_test.py
@@ -19,7 +19,7 @@ def mock_responses():
 class TestCity:
 
     @staticmethod
-    def test_get_city(mock_responses):
+    def test_get_cities(mock_responses):
         response = {
             'result': [
                 {
@@ -75,8 +75,8 @@ class TestCity:
             json=response,
         )
 
-        mealpal = mealpy.MealPal()
-        city = mealpal.get_city('San Francisco')
+        cities = mealpy.get_cities()
+        city = [i for i in cities if i['name'] == 'San Francisco'][0]
 
         assert city.items() >= {
             'id': 'mock_id1',
@@ -85,41 +85,15 @@ class TestCity:
         }.items()
 
     @staticmethod
-    def test_get_city_not_found(mock_responses):
-        response = {
-            'result': [
-                {
-                    'id': 'mock_id1',
-                    'objectId': 'mock_objectId1',
-                    'state': 'CA',
-                    'name': 'San Francisco',
-                    'city_code': 'SFO',
-                },
-            ],
-        }
-
-        mock_responses.add(
-            responses.RequestsMock.POST,
-            mealpy.CITIES_URL,
-            json=response,
-        )
-
-        mealpal = mealpy.MealPal()
-        city = mealpal.get_city('Not San Francisco')
-
-        assert not city
-
-    @staticmethod
-    def test_get_city_bad_response(mock_responses):
+    def test_get_cities_bad_response(mock_responses):
         mock_responses.add(
             responses.RequestsMock.POST,
             mealpy.CITIES_URL,
             status=400,
         )
 
-        mealpal = mealpy.MealPal()
         with pytest.raises(requests.exceptions.HTTPError):
-            mealpal.get_city('Not San Francisco')
+            mealpy.get_cities()
 
 
 class TestLogin:


### PR DESCRIPTION
```bash
$ python -m mealpy list cities
$ python -m mealpy list restaurants 'San Francisco'
$ python -m mealpy list meals 'San Francisco'
```

I discovered that the endpoints for cities and schedules are stateless, can be simply GET or POST directly. So i moved the functions outside the `Mealpal` class.

This is an initial pass at #7, will enable the primary use case: an easy way to list valid values for input to the script.